### PR TITLE
Add base docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,72 @@
+version: 2.1
+
+orbs:
+  codacy: codacy/base@1.0.0
+
+jobs:
+  build:
+    machine: true
+    working_directory: ~/workdir
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Build 'runtime' target
+          command: ./build.sh runtime
+      - run:
+          name: Build 'build' target
+          command: ./build.sh build
+      - run:
+          name: Save docker to file
+          command: |
+            docker save --output ~/workdir/docker-image.tar \
+              "codacy/${CIRCLE_PROJECT_REPONAME}-runtime:$(cat .version)" \
+              "codacy/${CIRCLE_PROJECT_REPONAME}-build:$(cat .version)"
+      - persist_to_workspace:
+          root: ~/
+          paths:
+            - workdir
+
+  publish:
+    machine: true
+    working_directory: ~/workdir
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Load docker from file
+          command: docker load --input ~/workdir/docker-image.tar
+      - run:
+          name: Publish to Docker Hub
+          command: |
+            docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
+
+            docker tag "codacy/${CIRCLE_PROJECT_REPONAME}-runtime:$(cat .version)" "codacy/${CIRCLE_PROJECT_REPONAME}-runtime:latest"
+            docker push "codacy/${CIRCLE_PROJECT_REPONAME}-runtime"
+
+            docker tag "codacy/${CIRCLE_PROJECT_REPONAME}-build:$(cat .version)" "codacy/${CIRCLE_PROJECT_REPONAME}-build:latest"
+            docker push "codacy/${CIRCLE_PROJECT_REPONAME}-build"
+
+
+workflows:
+  version: 2
+  test-and-publish:
+    jobs:
+      - codacy/checkout_and_version:
+          write_sbt_version: false
+      - build:
+          context: CodacyDocker
+          requires:
+            - codacy/checkout_and_version
+
+      - publish:
+          filters:
+            branches:
+              only:
+                - master
+          requires:
+            - build
+
+      - codacy/tag_version:
+          requires:
+            - publish

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+ARG base_image=alpine:3.10
+FROM $base_image
+
+LABEL maintainer="Codacy <team@codacy.com>"
+
+ARG add_packages=""
+
+RUN apk add --no-cache mono $add_packages --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing && \
+	apk add --no-cache --virtual=.build-dependencies ca-certificates && \
+	cert-sync /etc/ssl/certs/ca-certificates.crt && \
+	apk del .build-dependencies \
+	rm /tmp/* \
+	rm -rf /var/cache/apk/*

--- a/README.md
+++ b/README.md
@@ -1,2 +1,44 @@
-# docker-dotnet
-Codacy docker image to build and run .NET applications
+# Codacy Docker for .NET and Mono
+
+[![Codacy Badge](https://api.codacy.com/project/badge/Grade/f06b7ebc88834c2cbf808c193713ec11)](https://www.codacy.com/app/Codacy/docker-dotnet-mono?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=codacy/docker-dotnet-mono&amp;utm_campaign=Badge_Grade)
+[![CircleCI](https://circleci.com/gh/codacy/docker-dotnet-mono.svg?style=svg)](https://circleci.com/gh/codacy/docker-dotnet-mono)
+[![Docker Version](https://images.microbadger.com/badges/version/codacy/docker-dotnet-mono.svg)](https://microbadger.com/images/codacy/docker-dotnet-mono "Get your own version badge on microbadger.com")
+
+Codacy docker image to build and run .NET applications with Mono.
+
+## Contents
+
+Dockerfile describing a docker containing:
+
+-  .NET Core SDK 2.2
+-  NuGet
+-  Mono
+
+## Build and Publish
+
+Check the complete list of available commands to build and publish this docker image by running:
+
+```sh
+make help
+```
+
+## What is Codacy
+
+[Codacy](https://www.codacy.com/) is an Automated Code Review Tool that monitors your technical debt,
+helps you improve your code quality, teaches best practices to your developers, and helps you save time in Code Reviews.
+
+## Among Codacy features
+
+-  Identify new Static Analysis issues
+-  Commit and Pull Request Analysis with GitHub, BitBucket/Stash, GitLab (and also direct git repositories)
+-  Auto-comments on Commits and Pull Requests
+-  Integrations with Slack, Jira, YouTrack
+-  Track issues Code Style, Security, Error Proneness, Performance, Unused Code and other categories
+
+Codacy also helps keep track of Code Coverage, Code Duplication, and Code Complexity.
+
+Codacy supports PHP, Python, Ruby, Java, JavaScript, and Scala, among others.
+
+## Free for Open Source
+
+Codacy is free for Open Source projects.

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+VERSION=$(cat .version 2>/dev/null || echo dev)
+
+if [ "$1" == "runtime" ];
+then
+	DOCKER_ARGS="--build-arg base_image=mcr.microsoft.com/dotnet/core/sdk:2.2-alpine3.9 --build-arg add_packages=make"
+elif [ "$1" != "build" ];
+then
+	echo "Invalid type! use 'runtime' or 'build'" 2>&1
+	exit 1
+fi
+
+docker build --no-cache -t "codacy/docker-dotnet-mono-$1:$VERSION" $DOCKER_ARGS .


### PR DESCRIPTION
This docker image should add `dotnet-sdk` and `mono` (also some useful linux packages for building and scripting). The purpose is to run it on circleci.

I choose Arch Linux, because of this:
```
codacy-docker-dotnet-mono     arch                d64a7bd477f3        1.41GB
codacy-docker-dotnet-mono     alpine              3e893b2327a0        1.76GB
mcr.microsoft.com/dotnet/core/sdk   2.2-alpine3.9       b09d371ebb5b        1.48GB
mcr.microsoft.com/dotnet/core/sdk   2.2                 2344653cce7d        1.74GB
```